### PR TITLE
fix(farm-extend): fix(farm-extend): Update `acc_reward_per_share` in …

### DIFF
--- a/pallets/farm-extend/src/lib.rs
+++ b/pallets/farm-extend/src/lib.rs
@@ -374,6 +374,7 @@ impl<T: Config> Pallet<T> {
 				}
 
 				if pool_extend.total_stake_amount == Balance::zero() {
+					pool_extend.last_reward_block = reward_block;
 					return Ok(());
 				}
 


### PR DESCRIPTION
…the same block

## Summary

Summary about this PR

## Changelog

- fix(farm-extend): update `acc_reward_per_share` field when `total_stake_amount` is zero.
- test(xx) add `withdraw_asset_should_work_2` unit test.